### PR TITLE
チェック機能の修正

### DIFF
--- a/whereis/whereis.go
+++ b/whereis/whereis.go
@@ -52,6 +52,7 @@ func Resolve(domain string, verbose bool) error {
 
 func (s *Summary) ParseWhoisResponse() error {
 	paragraph := s.BreakDownWhoisResponseIntoParagraphs()
+	fmt.Println(paragraph)
 	for _, v := range paragraph {
 		tmp := NetworkAdomin{}
 		row := strings.Split(v, "\n")
@@ -122,7 +123,7 @@ func (s *Summary) ParseCheck() bool {
 	// 転送されていないかチェックする
 	list := []string{"apnic", "arin", "ripe", "lacnic"}
 	for _, v := range list {
-		if v == strings.ToLower(s.ParseResult[1].NetName) {
+		if strings.Contains(strings.ToLower(s.ParseResult[1].NetName), v) {
 			s.WhoisResponseServer = fmt.Sprintf("whois.%s.net", v)
 			return false
 		}

--- a/whereis/whereis.go
+++ b/whereis/whereis.go
@@ -39,7 +39,7 @@ func Resolve(domain string, verbose bool) error {
 	summary.SetWhoisResponseServerFromWhoisResponse()
 	summary.ParseWhoisResponse()
 	if !summary.ParseCheck() {
-		summary.ParseResult = nil
+		summary.ParseResult = summary.ParseResult[1:]
 		summary.WhoisResponse, err = whois.Whois(summary.TargetIp, summary.WhoisResponseServer)
 		if err != nil {
 			return err
@@ -52,7 +52,6 @@ func Resolve(domain string, verbose bool) error {
 
 func (s *Summary) ParseWhoisResponse() error {
 	paragraph := s.BreakDownWhoisResponseIntoParagraphs()
-	fmt.Println(paragraph)
 	for _, v := range paragraph {
 		tmp := NetworkAdomin{}
 		row := strings.Split(v, "\n")


### PR DESCRIPTION
# 概要
転送チェックに不備があったので修正します。

`Asia Pacific Network Information Centre (APNIC)` と返ってきている場合があり、想定していた分岐になっていなかったので、文字列に該当文字列があるかチェックする条件に変更します。
また、転送された場合のRootがなくなっていたのでその点も修正します