### PR TITLE
Update the version of go used in the release action to 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       -
         name: Create tag
         id: create-tag


### PR DESCRIPTION
# summary
see. https://github.com/goreleaser/goreleaser/issues/2066

The following release action is causing an error, so we will increase the version used to resolve the issue.
https://github.com/harakeishi/whris/runs/6534109698?check_suite_focus=true
